### PR TITLE
ci: update actions/checkout to v4

### DIFF
--- a/.github/workflows/gem.yml
+++ b/.github/workflows/gem.yml
@@ -19,7 +19,7 @@ jobs:
           - 2.7
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
the other versions are no longer supported
