### PR TITLE
fix: use the correct default branch name

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
We haven't made the switch to `main` yet as the default branch so I needed to add the existing default branch so the workflow triggers.
