### PR TITLE
fix: update release workflow name

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: "Release Please"
+name: "Release, Please!"
 
 on:
   push:


### PR DESCRIPTION
Meant to do this before publishing 0.3.0 but forgot, so it'll go in the next release
